### PR TITLE
Treat print_footer_scripts like a filter and return the intended value

### DIFF
--- a/components/late-enqueue.php
+++ b/components/late-enqueue.php
@@ -26,10 +26,10 @@ function bcms_late_enqueue_style( $handle, $src = false, $deps = array(), $ver =
 	$wp_styles->all_deps( array( $handle ));
 	$wp_styles->in_footer = array_merge( (array) $wp_styles->in_footer , (array) array_diff( (array) $wp_styles->to_do , $to_do_orig ) );
 
-	add_filter( 'print_footer_scripts', 'bcms_print_late_styles' );
+	add_filter( 'print_footer_scripts', 'bcms_print_late_styles', 10, 1 );
 }
 
-function bcms_print_late_styles()
+function bcms_print_late_styles( $finish_print )
 {
 	global $wp_styles;
 
@@ -49,7 +49,7 @@ function bcms_print_late_styles()
 	}		
 
 	if( ! array( $tags ))
-		return;
+		return $finish_print;
 
 ?>
 <script type="text/javascript">	
@@ -65,5 +65,6 @@ function bcms_print_late_styles()
 	})(jQuery);
 </script>
 <?php
+	return $finish_print;
 }
 

--- a/components/postloops.php
+++ b/components/postloops.php
@@ -405,7 +405,7 @@ class bCMS_PostLoop_Scroller
 		// register scripts and styles
 		wp_register_script( 'scrollable', $this->path_web . '/js/scrollable.min.js', array('jquery'), TRUE );
 		bcms_late_enqueue_script( 'scrollable' );
-		add_filter( 'print_footer_scripts', array( $this, 'print_js' ));
+		add_filter( 'print_footer_scripts', array( $this, 'print_js' ), 10, 1 );
 
 		if( $this->settings->css )
 		{
@@ -414,7 +414,7 @@ class bCMS_PostLoop_Scroller
 		}
 	}
 
-	function print_js()
+	function print_js( $finish_print )
 	{
 ?>
 <script type="text/javascript">	
@@ -439,6 +439,7 @@ class bCMS_PostLoop_Scroller
 	})(jQuery);
 </script>
 <?php
+		return $finish_print;
 	}
 }
 

--- a/components/wijax.php
+++ b/components/wijax.php
@@ -28,7 +28,7 @@ class bSuite_Wijax
 		{
 			wp_register_script( 'waypoints', $this->path_web . '/js/waypoints.min.js', array('jquery'), '1' );
 			wp_enqueue_script( 'waypoints' );
-			add_filter( 'print_footer_scripts', array( &$this, 'print_js' ));
+			add_filter( 'print_footer_scripts', array( &$this, 'print_js' ), 10, 1 );
 		}
 	}
 
@@ -219,7 +219,7 @@ class bSuite_Wijax
 		call_user_func_array( $widget_data['callback'], $widget_data['params'] );
 	}
 
-	function print_js(){
+	function print_js( $finish_print ){
 ?>
 <script type="text/javascript">	
 	var wijax_widget_reload = true;	
@@ -288,6 +288,7 @@ class bSuite_Wijax
 	})(jQuery);
 </script>
 <?php
+		return $finish_print;
 	}
 
 } //end bSuite_Wijax


### PR DESCRIPTION
While debugging the way concatenated scripts works, I discovered that the print_footer_script in bcms (and GigaOM's go-datamodule plugin) were treating the filter as an action.  The function `print_footer_scripts` in `wp-includes/script-loader.php` uses the filter to determine whether or not to fire off `_print_scripts`, which handles concatenation logic.
