### PR TITLE
- Switching from document to window when checking for scroll event.

### DIFF
--- a/components/wijax.php
+++ b/components/wijax.php
@@ -279,7 +279,7 @@ class bSuite_Wijax
 		});	
 
 		// do the onscroll actions
-		$(document).one('scroll', function(){
+		$(window).one('scroll', function(){
 			// widgets
 			$('a.wijax-source.wijax-onscroll').each(function() {
 				$(this).myWijaxLoader();


### PR DESCRIPTION
a. Solves issue with missed scroll events in IE 8.
