### PR TITLE
Watch for ajax events and notify parent frame of any changes to height

### DIFF
--- a/components/js/bcms-wiframe-notify.js
+++ b/components/js/bcms-wiframe-notify.js
@@ -1,7 +1,25 @@
 jQuery(function( $ ) {
-	$(window).load( function() {
-		var parent_url = decodeURIComponent( document.location.hash.replace( /^#/, '' ) );
+	var bcms_wiframe_parent_url = decodeURIComponent( document.location.hash.replace( /^#/, '' ) );
+	var bcms_wiframe_height = 0;
 
-		$.postMessage({ bcms_wiframe_height: $('body').outerHeight( true ) }, parent_url, parent );
+	function bcms_wiframe_height_notify() {
+		var height = $('body').outerHeight( true );
+
+		if ( height === bcms_wiframe_height ) {
+			return;
+		}//end if
+
+		bcms_wiframe_height = height;
+
+		$.postMessage({ bcms_wiframe_height: height }, bcms_wiframe_parent_url, parent );
+	}//end bcms_wiframe_height_notify
+
+	$(window).load( bcms_wiframe_height_notify );
+
+	// Watch for ajax events.  When they occur, notify if needed but after a short delay
+	$(document).ajaxComplete( function() {
+		setTimeout( function() {
+			bcms_wiframe_height_notify();
+		}, 300 );
 	});
 });


### PR DESCRIPTION
Ajax events can sometimes cause the page to grow or shrink.  To accomodate that, watching for the completion of those events are important for resizing the parent iframe.  The resize occurs after a short delay to prevent communicating too soon.
