### PR TITLE
fixed a php warning/bug

### DIFF
--- a/components/class-bcms-search.php
+++ b/components/class-bcms-search.php
@@ -246,7 +246,7 @@ class bCMS_Search
 
 		echo '<h2>bCMS Search reindex</h2><p>processed ' . $count . ' post(s) at '. date( DATE_RFC822 ) .'</p>';
 
-		if ( $reindex_limit <= $count )
+		if ( $this->reindex_limit <= $count )
 		{
 			echo '<p>Reloading...</p>';
 ?>


### PR DESCRIPTION
bcms would never stop when it has indexed all the post content because it couldn't get the real value of reindex_limit. this also gets rid of a php warning.
