### PR TITLE
Preserve some values for nested postloops

### DIFF
--- a/components/class-bcms-postloop-widget.php
+++ b/components/class-bcms-postloop-widget.php
@@ -489,6 +489,7 @@ class bCMS_PostLoop_Widget extends WP_Widget {
 				'ttl' => $this->ttl,
 				'use_cache' => $this->use_cache,
 			);
+
 			// new actions
 			bcms_postloop()->do_action( 'post', $instance['template'], 'after', $ourposts, $this, $instance );
 
@@ -530,7 +531,6 @@ class bCMS_PostLoop_Widget extends WP_Widget {
 					'post_ids' => bcms_postloop()->posts[ $preserve['number'] ],
 					'time' => time(),
 				);
-				//do_action( 'debug_robot', print_r( $cache_data, TRUE ) );
 				wp_cache_set( $cachekey, $cache_data, 'bcmspostloop', $preserve['ttl'] );
 				unset( $cache_data );
 			}//end if


### PR DESCRIPTION
Applies to https://github.com/GigaOM/legacy-pro/issues/3276

If post loops are nested, they can overwrite values in the singleton - wrecking the cached post ids for the parent loop.

This allows preservation of those values so that cached post ids are connected to the correct post loop.
