### PR TITLE
Wijax hasn't supported /page/X URLs with the /wijax/blah endpoint

### DIFF
--- a/components/class-bcms-wijax-widget.php
+++ b/components/class-bcms-wijax-widget.php
@@ -46,6 +46,9 @@ class bCMS_Wijax_Widget extends WP_Widget
 			$wijax_source .= "?{$_SERVER['QUERY_STRING']}";
 		}//end if
 
+		// wijax doesn't work with paging. Let's strip out the "page/X/" section of the URL, which should help with cached wijax widgets
+		$wijax_source = preg_replace( '#/page/[0-9]+/wijax#', '/wijax', $wijax_source );
+
 		$wijax_varname = $mywijax->varname( $wijax_source, $is_local );
 
 		echo $args['before_widget'];


### PR DESCRIPTION
Here's the rewrite rules that exist currently for Gigaom Research:

![screen shot 2014-07-31 at 4 39 27 pm](https://cloud.githubusercontent.com/assets/430385/3771183/c9580aec-18f2-11e4-8bc0-cc0ad225fa66.png)

Stripping out the `/page/x/` section of the URL is the easy thing to do and shouldn't reduce functionality. Long term, it might be a good plan to find a way to add page support for wijax, maybe? The only catch there would be that each "page" would cache the request separately due to the changing wijax URL.

These would all cache separately, wouldn't they?

```
/property/researc/wijax/asdf/
/property/researc/page/2/wijax/asdf/
/property/researc/page/3/wijax/asdf/
```

See: https://github.com/GigaOM/legacy-pro/issues/3428
